### PR TITLE
Add TSF docs callout to welcome page + header link

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -8,7 +8,17 @@ hide_table_of_contents: false
 
 # Diva Staking protocol
 
-Welcome to the comprehensive technical documentation of the Diva Staking protocol, designed to provide a detailed insight into the testnet environment, technical overviews, and intricate protocol details. Whether you're a developer, enthusiast, or simply curious about the inner workings of DIVA, this documentation aims to shed light on the intricacies of the system. From navigating the testnet to diving into the protocol's underlying mechanisms, you'll find information here to help you grasp the essence of the Diva Staking protocol. You can also find additional information independently maintained by the [Staking Foundation](https://docs.staking.foundation).
+Welcome to the comprehensive technical documentation of the Diva Staking protocol, designed to provide a detailed insight into the testnet environment, technical overviews, and intricate protocol details.
+
+Whether you're a developer, enthusiast, or simply curious about the inner workings of DIVA, this documentation aims to shed light on the intricacies of the system. From navigating the testnet to diving into the protocol's underlying mechanisms, you'll find information here to help you grasp the essence of the Diva Staking protocol.
+
+:::info New to Diva?
+
+👉 [Start with the Diva Staking docs](https://docs.staking.foundation), independently maintained, to learn about Liquid Staking, Operators, Distributed Validation, Staking Rewards and much more.
+
+This will give you a basic understanding of the Diva system, after which you can come back here to learn how to set up a node.
+:::
+
 
 ## Where do I start?
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,6 +97,11 @@ const config = {
         },
         items: [
           {
+            href: 'https://docs.staking.foundation/',
+            label: 'Diva Staking docs',
+            position: 'right',
+          },
+          {
             href: 'https://shamirlabs.medium.com',
             label: 'Medium',
             position: 'right',


### PR DESCRIPTION
Minor edits to:

- Improve readability by breaking a long paragraph
- Adding a graphic callout to those who need to learn about Diva before installing.
- Add "Diva Staking docs" to header as an external link

Screenshot: see header, main content

![image](https://github.com/shamirlabs/docs/assets/323401/a67e1064-2601-461a-89ec-014e257c3f76)

