### PR TITLE
Fix broken relative links on Cloudflare Pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,12 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/shamirlabs.png',
 
+  // "false" generates testnet/intro.html instead of testnet/intro/index.html
+  // when deployed to cloudflare pages, /testnet/intro gets redirected to /testnet/intro/
+  // and relative links on the page don't work when the page is refreshed
+  // cloudflare page serves testnet/intro.html at /testnet/intro
+  trailingSlash: false,
+
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'shamirlabs', // Usually your GitHub org/user name.


### PR DESCRIPTION
Relative links in the docs are broken because of a trailing slash `/` in production.

In development links work on http://localhost:3000/diva/testnet/intro
but they don't work on http://localhost:3000/diva/testnet/intro/

In production you can't get to https://docs.shamirlabs.org/diva/testnet/intro
it gets redirected to https://docs.shamirlabs.org/diva/testnet/intro/

```
$ curl https://docs.shamirlabs.org/diva/testnet/intro -I --http1.1
HTTP/1.1 308 Permanent Redirect
Location: /diva/testnet/intro/
```

If you're on https://docs.shamirlabs.org/ and click `Join the testnet` you'll end up on https://docs.shamirlabs.org/diva/testnet/intro and links will work

If you then refresh the page or follow the link to https://docs.shamirlabs.org/diva/testnet/intro from somewhere else, a trailing slash will be added to the url and the links don't work.

If you're using Cloudflare Pages then it doesn't look like it's easy to disable this: https://community.cloudflare.com/t/cloudflare-pages-get-rid-of-redundat-308-redirect/324582

If you add `trailingSlash: false` to `docusaurus.config.js` it'll generate `testnet/intro.html` instead of `testnet/intro/index.html`. Cloudflare Pages should serve `intro.html` at `/intro`.  Hopefully this works (not tested).